### PR TITLE
Add github workflow to publish all rocks

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -1,0 +1,50 @@
+name: BuildAll
+
+on:
+  workflow_call:
+
+
+jobs:
+  allrocks:
+    runs-on: ubuntu-latest
+    outputs:
+      rocks: ${{ steps.all-rocks.outputs.rocks }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: List rockcraft files
+        id: list-files
+        run: |
+          all_rock_files=$(find rocks -name rockcraft.yaml -printf "%p ")
+          echo "All rock files: $all_rock_files"
+          echo "all_rock_files=$all_rock_files" >> $GITHUB_OUTPUT
+      - name: set output
+        id: all-rocks
+        run: |
+          components=()
+          # trim file name to component name
+          for file in ${{ steps.list-files.outputs.all_rock_files }}; do
+              component=$(echo $file | sed 's/rocks\/\(\S.*\)\/rockcraft.yaml/\1/')
+              [[ ! -z "$component" ]] && components+=($component)
+          done
+          all_rocks=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${components[@]}")
+          echo "All rocks: $all_rocks"
+          echo "rocks=$all_rocks" >> $GITHUB_OUTPUT
+  build:
+    needs: allrocks
+    if: ${{ needs.allrocks.outputs.rocks != '[]' }}
+    strategy:
+      matrix:
+        rock: ${{ fromJson(needs.allrocks.outputs.rocks) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: canonical/craft-actions/rockcraft-pack@main
+        id: rockcraft
+        with:
+          path: rocks/${{ matrix.rock }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rock
+          path: ${{ steps.rockcraft.outputs.rock }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build-all.yaml

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build-all.yaml
 
   publish:
     needs: build


### PR DESCRIPTION
Add workflow to publish all the rocks.
Enable build-all to publish all the rocks.
Note build-all should be reverted back so
that we will build and publish only modified
rocks.