### PR TITLE
Switch magnum to proposed pocket from UCA

### DIFF
--- a/rocks/magnum-api/rockcraft.yaml
+++ b/rocks/magnum-api/rockcraft.yaml
@@ -12,6 +12,8 @@ package-repositories:
   - type: apt
     cloud: antelope
     priority: always
+    # magnum 16.0.1 needed to work with barbican
+    pocket: proposed
 
 services:
   wsgi-magnum-api:

--- a/rocks/magnum-conductor/rockcraft.yaml
+++ b/rocks/magnum-conductor/rockcraft.yaml
@@ -12,6 +12,8 @@ package-repositories:
   - type: apt
     cloud: antelope
     priority: always
+    # magnum 16.0.1 needed to work with barbican
+    pocket: proposed
 
 services:
   magnum-conductor:

--- a/rocks/magnum-consolidated/rockcraft.yaml
+++ b/rocks/magnum-consolidated/rockcraft.yaml
@@ -12,6 +12,8 @@ package-repositories:
   - type: apt
     cloud: antelope
     priority: always
+    # magnum 16.0.1 needed to work with barbican
+    pocket: proposed
 
 parts:
   magnum-user:


### PR DESCRIPTION
Bug [1] between magnum and barbican has been fixed in magnum 16.0.1 which is currently served in proposed pocket.

[1]: https://storyboard.openstack.org/#!/story/2010629