### PR TITLE
Refactor horizon plugins + add heat

### DIFF
--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -56,17 +56,15 @@ parts:
       craftctl default
       chmod 550 $CRAFT_PRIME/usr/bin/plugin_management.py
 
-  horizon-magnum-plugin:
+  horizon-plugins:
     after: [horizon]
     plugin: nil
     stage-packages:
+      - python3-heat-dashboard
       - python3-magnum-ui
+      - python3-octavia-dashboard
     organize:
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1370_project_container_infra_panel_group.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1370_project_container_infra_panel_group.py
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1371_project_container_infra_clusters_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1371_project_container_infra_clusters_panel.py
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1372_project_container_infra_cluster_templates_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1372_project_container_infra_cluster_templates_panel.py
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_2370_admin_container_infra_panel_group.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_2370_admin_container_infra_panel_group.py
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_2371_admin_container_infra_quotas_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_2371_admin_container_infra_quotas_panel.py
+      usr/lib/python3/dist-packages/openstack_dashboard/enabled/*: usr/lib/python3/dist-packages/openstack_dashboard/available/
     override-prime: |
       craftctl default
       echo "_1370_project_container_infra_panel_group.py
@@ -74,14 +72,9 @@ parts:
       _1372_project_container_infra_cluster_templates_panel.py
       _2370_admin_container_infra_panel_group.py
       _2371_admin_container_infra_quotas_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/magnum
-
-  horizon-octavia-plugin:
-    after: [horizon]
-    plugin: nil
-    stage-packages:
-      - python3-octavia-dashboard
-    organize:
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/_1482_project_load_balancer_panel.py: usr/lib/python3/dist-packages/openstack_dashboard/available/_1482_project_load_balancer_panel.py
-    override-prime: |
-      craftctl default
       echo "_1482_project_load_balancer_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/octavia
+      echo "_1610_project_orchestration_panel.py
+      _1620_project_stacks_panel.py
+      _1630_project_resource_types_panel.py
+      _1640_project_template_versions_panel.py
+      _1650_project_template_generator_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/heat


### PR DESCRIPTION
Heat and Magnum packages share files but with different permission. This is not allowed in different Rockcraft parts. Merge all the parts to fix the issue, and simplify the Rockcraft file.