### PR TITLE
Enable publishing on pushing to stable

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - stable/2023.1
 
 jobs:
   build:


### PR DESCRIPTION
If any change is made to stable/2023.1, github should automatically publish the changes.