### PR TITLE
Fix retrieving rock name in publish_branch workflow

### DIFF
--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Import and push to github package
         run: |
           rock_file="${{ steps.rockcraft.outputs.rock }}"
-          rockname=$(echo $rock_file | cut -d"_" -f1)
+          rockname=$(echo $rock_file | cut -d"/" -f2)
           image_name="$(yq '.name' rocks/$rockname/rockcraft.yaml)"
           version="$(yq '.version' rocks/$rockname/rockcraft.yaml)"
           sudo skopeo \


### PR DESCRIPTION
publish_branch workflow build-and-publish step
retrieves incorrect value for rock name.
Step rockcraft outputs rock file path from running directory instead of just rock filename. So modify retrieving rockname logic by using cut.