### PR TITLE
publich-brnach: pass branch to publish-rock

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -12,6 +12,10 @@ on:
             description: Publish rocks ?
             default: false
             type: boolean
+        branch:
+            description: Branch to build from
+            required: true
+            default: main
 
 jobs:
   build-and-publish:
@@ -24,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
         with:

--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -51,4 +51,5 @@ jobs:
     uses: ./.github/workflows/build_publish.yaml
     with:
       rocks: ${{ needs.allrocks.outputs.rocks }}
+      branch: ${{ inputs.branch }}
       publish: true


### PR DESCRIPTION
This ensures the workflow works with any branch rather than just the main branch.