### PR TITLE
Install python3-memcache library in horizon

### DIFF
--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -42,6 +42,7 @@ parts:
     overlay-packages:
       - sudo
       - openstack-dashboard
+      - python3-memcache
       - python3-designate-dashboard
       - python3-mysqldb
     override-prime: |


### PR DESCRIPTION
Memcache library dependency was removed in bobcat, adding it back in because to keep old behavior (failing silently) while it's fixed.