### PR TITLE
Use trigger ref when building rocks on pull request

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -13,3 +13,4 @@ jobs:
     with:
       rocks: ${{ needs.modified_rocks.outputs.rocks }}
       publish: false
+      branch: ${{ github.ref }}


### PR DESCRIPTION
Since branch was passed to the build-and-publish workflow, the input branch was made optional with default "main".
In case of a pull request, we want the workflow to run on the PR's branch, and not main.