### PR TITLE
Allow push on other branch than main

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,3 +16,4 @@ jobs:
     with:
       rocks: ${{ needs.modified_rocks.outputs.rocks }}
       publish: true
+      branch: ${{ github.ref }}


### PR DESCRIPTION
Since the branch possibility update, another branch than main was not possible in push workflow; Add branch ref.