### PR TITLE
Add ca-certificates to tempest rock

### DIFF
--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -33,6 +33,9 @@ parts:
       # Give permission and create the required directories
       mkdir -p $CRAFT_PRIME/var/lib/tempest
       chown -R 999:999 $CRAFT_PRIME/var/lib/tempest
+    overlay-packages:
+      # this must be in overlay-packages - see https://github.com/canonical/rockcraft/issues/334
+      - ca-certificates # required for discover-tempest-config to download cirros image
 
   snap-tempest:
     after: [tempest-user]


### PR DESCRIPTION
To address errors downloading cirros image by discover-tempest-config

```
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:02.346 22 INFO config_tempest.constants [-] Creating image 'cirros-0.5.2-x86_64-disk.img'
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:02.346 22 INFO config_tempest.constants [-] Downloading 'https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img' and saving as '/var/lib/tempest/etc/cirros-0.5.2-x86_64-disk.img'
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:03.030 22 WARNING config_tempest.constants [-] <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>, Retrying in 3 seconds.: urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:06.454 22 WARNING config_tempest.constants [-] <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>, Retrying in 6 seconds.: urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:12.888 22 WARNING config_tempest.constants [-] <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>, Retrying in 12 seconds.: urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:25.314 22 INFO config_tempest.constants [-] Uploading image 'cirros-0.5.2-x86_64-disk.img' from '/var/lib/tempest/etc/cirros-0.5.2-x86_64-disk.img'
unit-tempest-0: 15:27:26 ERROR unit.tempest/0.juju-log     2024-02-13 04:57:25.314 22 CRITICAL tempest [-] Unhandled error: FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/tempest/etc/cirros-0.5.2-x86_64-disk.img'
```