### PR TITLE
Move plugins to overlay, manage available plugins in prime step

### DIFF
--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -45,38 +45,55 @@ parts:
       - python3-memcache
       - python3-designate-dashboard
       - python3-mysqldb
-    override-prime: |
-      craftctl default
-      echo > $CRAFT_PRIME/etc/apache2/ports.conf
-    
-  horizon-plugin:
-    plugin: dump
-    source: python/
-    organize:
-     plugin_management.py: usr/bin/plugin_management.py
-    override-prime: |
-      craftctl default
-      chmod 550 $CRAFT_PRIME/usr/bin/plugin_management.py
-
-  horizon-plugins:
-    after: [horizon]
-    plugin: nil
-    stage-packages:
+      # Horizon plugins needing manual management
       - python3-heat-dashboard
       - python3-magnum-ui
       - python3-octavia-dashboard
-    organize:
-      usr/lib/python3/dist-packages/openstack_dashboard/enabled/*: usr/lib/python3/dist-packages/openstack_dashboard/available/
-    override-prime: |
+    override-stage: |
       craftctl default
+      echo > $CRAFT_STAGE/etc/apache2/ports.conf
+
+      OS_DASHBOARD=usr/lib/python3/dist-packages/openstack_dashboard
+      AVAILABLE=$OS_DASHBOARD/available
+      mkdir -p $CRAFT_STAGE/$AVAILABLE || true
       echo "_1370_project_container_infra_panel_group.py
       _1371_project_container_infra_clusters_panel.py
       _1372_project_container_infra_cluster_templates_panel.py
       _2370_admin_container_infra_panel_group.py
-      _2371_admin_container_infra_quotas_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/magnum
-      echo "_1482_project_load_balancer_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/octavia
+      _2371_admin_container_infra_quotas_panel.py" > $CRAFT_STAGE/$AVAILABLE/magnum
+      echo "_1482_project_load_balancer_panel.py" > $CRAFT_STAGE/$AVAILABLE/octavia
       echo "_1610_project_orchestration_panel.py
       _1620_project_stacks_panel.py
       _1630_project_resource_types_panel.py
       _1640_project_template_versions_panel.py
-      _1650_project_template_generator_panel.py" > $CRAFT_PRIME/usr/lib/python3/dist-packages/openstack_dashboard/available/heat
+      _1650_project_template_generator_panel.py" > $CRAFT_STAGE/$AVAILABLE/heat
+    override-prime: |
+      craftctl default
+
+      OS_DASHBOARD=usr/lib/python3/dist-packages/openstack_dashboard
+      AVAILABLE=$OS_DASHBOARD/available
+      ENABLED=$OS_DASHBOARD/enabled
+      mkdir -p $CRAFT_PRIME/$AVAILABLE || true
+
+      plugin_files=$(ls $CRAFT_STAGE/$AVAILABLE)
+      for plugin_file in $plugin_files; do
+        echo "Processing $plugin_file"
+        cp $CRAFT_STAGE/$AVAILABLE/$plugin_file $CRAFT_PRIME/$AVAILABLE/$plugin_file
+        while read line; do
+          enable_file=$CRAFT_STAGE/$ENABLED/$line
+          available_file=$CRAFT_PRIME/$AVAILABLE/$line
+          [[ -f $enable_file ]] && mv $enable_file $available_file
+          [[ ! -f $available_file ]] && echo "File $available_file not found" && exit 1
+        done < $CRAFT_STAGE/$AVAILABLE/$plugin_file
+      done
+      # load bearing echo, do not remove
+      echo processed plugin files
+
+  horizon-plugin:
+    plugin: dump
+    source: python/
+    organize:
+      plugin_management.py: usr/bin/plugin_management.py
+    override-prime: |
+      craftctl default
+      chmod 550 $CRAFT_PRIME/usr/bin/plugin_management.py


### PR DESCRIPTION
Horizon plugins packages perform extra steps in postinstall scripts that are need for a fully functional experience.
Add these packages to the overlay step, and manage enablement in prime step.