### PR TITLE
Create configuration folder as _daemon_ owned

### DIFF
--- a/rocks/openstack-exporter/README.md
+++ b/rocks/openstack-exporter/README.md
@@ -17,7 +17,7 @@ it will help ensure that all layers of the image are imported
 into docker (this is just the top layer).
 
 ```bash
-> skopeo --insecure-policy copy oci-archive:openstack-exporter_1.6.0-7533071_amd64.rock docker-daemon:openstack-exporter:1.6.0-7533071
+> skopeo --insecure-policy copy oci-archive:openstack-exporter_1.7.0_amd64.rock docker-daemon:openstack-exporter:1.7.0
 ```
 
 If you are interested in giving it a go in Microk8s, you can
@@ -25,8 +25,8 @@ export the image from your docker registry and then into the
 microk8s registry:
 
 ```bash
-> docker save openstack-exporter:1.6.0-7533071 > ./openstack-exporter_1.6.0-7533071.tar
-> microk8s ctr image import ./openstack-exporter_1.6.0-7533071.tar
+> docker save openstack-exporter:1.7.0 > ./openstack-exporter_1.7.0.tar
+> microk8s ctr image import ./openstack-exporter_1.7.0.tar
 # Try with sunbeam
-> juju attach-resource openstack-exporter openstack-exporter-image=openstack-exporter:1.6.0-7533071
+> juju attach-resource openstack-exporter openstack-exporter-image=openstack-exporter:1.7.0
 ```

--- a/rocks/openstack-exporter/rockcraft.yaml
+++ b/rocks/openstack-exporter/rockcraft.yaml
@@ -23,4 +23,12 @@ parts:
       - CGO_ENABLED: "0"
       - GOFLAGS: -mod=readonly -ldflags=-s
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
+    override-prime: |
+      craftctl default
+      folders=(/etc/os-exporter /usr/local/share/ca-certificates)
+      for folder in "${folders[@]}"; do
+        mkdir -p $CRAFT_PRIME/$folder
+        chown 584792:584792 $CRAFT_PRIME/$folder
+        chmod 750 $CRAFT_PRIME/$folder
+      done


### PR DESCRIPTION
With the move to juju 3.5, the pebble daemon is started with uid/gid of the user `_daemon_`. This fails in the charm since it's trying to create files where it does not have rights to. Pre-create them in the rock.