### PR TITLE
Add missing iptuils-ping dependency

### DIFF
--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -46,3 +46,4 @@ parts:
     stage-packages:
     - cron
     - python3-venv # this is required for python plugin
+    - iputils-ping


### PR DESCRIPTION
The tempest snap would in a classic or core system have access to the `ping` command from the base snap.

However it is not brought along when put into a rock, explicitly add the dependency.

Closes-Bug: #2071591