### PR TITLE
Publish directly to ghcr registry

### DIFF
--- a/.github/actions/publish-rock/action.yaml
+++ b/.github/actions/publish-rock/action.yaml
@@ -13,12 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Log in to the Container registry
-      uses: docker/login-action@v3.2.0
-      with:
-        registry: ghcr.io
-        username: ${{ inputs.username }}
-        password: ${{ inputs.password }}
     - name: Install skopeo
       shell: bash
       run: |
@@ -27,6 +21,10 @@ runs:
     - name: Install yq
       shell: bash
       run: sudo snap install yq
+    - name: Log in to the Container registry
+      shell: bash
+      run: |
+        skopeo login ghcr.io --username "${{ inputs.username }}"" --password "${{ inputs.password }}"
     - name: Import and push to github package
       shell: bash
       run: |
@@ -34,10 +32,14 @@ runs:
         rockdir=$(dirname $rock_file)
         image_name="$(yq '.name' $rockdir/rockcraft.yaml)"
         version="$(yq '.version' $rockdir/rockcraft.yaml)"
+        echo "Publishing rock ${image_name}:${version}"
         sudo skopeo \
           --insecure-policy \
           copy \
           oci-archive:"${rock_file}" \
-          docker-daemon:"ghcr.io/canonical/${image_name}:${version}"
-        echo "Publishing rock ${image_name}:${version}"
-        docker push ghcr.io/canonical/${image_name}:${version}
+          docker://"ghcr.io/canonical/${image_name}:${version}"
+    - name: Log out of the Container registry
+      if: always()
+      shell: bash
+      run: |
+        skopeo logout ghcr.io


### PR DESCRIPTION
Don't pass by intermediate docker daemon to publish the OCI image.