### PR TITLE
[github workflow] Pin lxd to 5.21/stable

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
         with:
-          channel: 5.21/candidate
-      - uses: canonical/craft-actions/rockcraft-pack@1de2f7678b7ecfd491bd8ec3c2d2f73fe722c643
+          channel: 5.21/stable
+      - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
         with:
           path: rocks/${{ matrix.rock }}


### PR DESCRIPTION
Commit b7a328ad518d91ae9b19c4e7ee264bbbe696befd pins lxd to 5.21/candidate to avoid mounting issues.
The issue is fixed now and released in 5.21/stable
Pin lxd to 5.21/stable.

rockcraft-pack main does not refresh the lxd if it already exists.
Pin rockcraft-pack to main.