### PR TITLE
Downgrade watcher and magnum to 22 base

### DIFF
--- a/rocks/magnum-api/rockcraft.yaml
+++ b/rocks/magnum-api/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack magnum-api
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 services:
   wsgi-magnum-api:

--- a/rocks/magnum-conductor/rockcraft.yaml
+++ b/rocks/magnum-conductor/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack magnum-conductor
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 services:
   magnum-conductor:

--- a/rocks/magnum-consolidated/rockcraft.yaml
+++ b/rocks/magnum-consolidated/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack magnum-consolidated
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 parts:
   magnum-user:

--- a/rocks/watcher-api/rockcraft.yaml
+++ b/rocks/watcher-api/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher API service
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 services:
   wsgi-watcher-api:

--- a/rocks/watcher-applier/rockcraft.yaml
+++ b/rocks/watcher-applier/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher applier service
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 services:
   watcher-applier:

--- a/rocks/watcher-consolidated/rockcraft.yaml
+++ b/rocks/watcher-consolidated/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher which can be used for all watcher services
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 parts:
   watcher-user:

--- a/rocks/watcher-decision-engine/rockcraft.yaml
+++ b/rocks/watcher-decision-engine/rockcraft.yaml
@@ -4,10 +4,15 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher decision engine service
 version: "2024.1"
-# renovate: base: ubuntu:24.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
-base: ubuntu@24.04
+# renovate: base: ubuntu:22.04@sha256:b359f1067efa76f37863778f7b6d0e8d911e3ee8efa807ad01fbf5dc1ef9006b
+base: ubuntu@22.04
 platforms:
   amd64:
+
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 services:
   watcher-decision-engine:


### PR DESCRIPTION
Magnum and Watcher exhibit python3.12 compatibility issues which are not planned to be fixed before 2025.1, downgrade back to ubuntu@22.04 to run python3.10.