### PR TITLE
Update tempest to epoxy

### DIFF
--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -6,11 +6,10 @@ description: |
   cluster. Tempest has batteries of tests for OpenStack API validation,
   Scenarios, and other specific tests useful in validating an OpenStack
   deployment. This ROCK is built using the snap-tempest.
-version: '2024.1'
+version: '2025.1'
 
 # renovate: base: ubuntu:22.04@sha256:1b8d8ff4777f36f19bfe73ee4df61e3a0b789caeff29caa019539ec7c9a57f95
 base: ubuntu@22.04
-
 platforms:
   amd64:
 
@@ -42,7 +41,7 @@ parts:
     plugin: python # we need to use python plugin because we need a python interpreter to run tempest internally
     source: .
     stage-snaps:
-    - tempest/2024.1/stable
+    - tempest/latest/candidate
     stage-packages:
     - cron
     - python3-venv # this is required for python plugin


### PR DESCRIPTION
Tempest's snap `latest/candidate` contains 43.0.0, epoxy release.