### PR TITLE
[tempest] Use tempest snap 2024.1/stable

### DIFF
--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -42,7 +42,7 @@ parts:
     plugin: python # we need to use python plugin because we need a python interpreter to run tempest internally
     source: .
     stage-snaps:
-    - tempest/2024.1/candidate
+    - tempest/2024.1/stable
     stage-packages:
     - cron
     - python3-venv # this is required for python plugin


### PR DESCRIPTION
Use tempest snap 2024.1/stable.
Tempest 41.x will be deployed.

(cherry picked from commit 4cbbc5097c14e866e1d55754010eecd306f2aa6c)