### PR TITLE
Minor fixes for cookiecutter rock generation

### DIFF
--- a/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
+++ b/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
@@ -13,6 +13,7 @@ package-repositories:
   - type: apt
     cloud: epoxy
     priority: always
+    pocket: proposed
 
 services:
   wsgi-{{ cookiecutter.rock_name }}:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = lint, py3
 sitepackages = False
 skip_missing_interpreters = False
 minversion = 3.18.0
-requires = virtualenv < 20.0
+requires = virtualenv < 21.0
 
 [vars]
 cookie_cutter_path = {toxinidir}/shared_code/sunbeam_charm/\{\{cookiecutter.service_name\}\}
@@ -28,3 +28,5 @@ deps =
 basepython = python3
 deps = -r{toxinidir}/cookiecutter_code/cookie-requirements.txt
 commands = /bin/true
+allowlist_externals =
+  /bin/true


### PR DESCRIPTION
When generating new rocks through cookiecutter, a few errors can occur:

- If the requirements are not met (`virtualenv < 20.0`), a new environment will be created, however, that will eventually fail with the following error: `ModuleNotFoundError: No module named 'distutils'`. Note that `distutils` has been removed in Python 3.12 [1].
- `/bin/true` is not in the tox `allowlist_externals`, resulting in this error: `failed with /bin/true (resolves to /bin/true) is not allowed, use allowlist_externals to allow it`.
- all other rocks are using the `proposed` pocket, the cookiecutter should too.

[1] https://docs.python.org/3/whatsnew/3.12.html#summary-release-highlights