### PR TITLE
Cleanup rocks

### DIFF
--- a/rocks/cinder-scheduler/rockcraft.yaml
+++ b/rocks/cinder-scheduler/rockcraft.yaml
@@ -15,8 +15,6 @@ package-repositories:
     cloud: epoxy
     priority: always
 
-
-
 services:
   cinder-scheduler:
     override: replace

--- a/rocks/heat-api/rockcraft.yaml
+++ b/rocks/heat-api/rockcraft.yaml
@@ -22,7 +22,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42418 --system heat
       useradd \
         --gid 42418 \
-        --uid 42418  \
+        --uid 42418 \
         --no-create-home \
         --home /var/lib/heat \
         --root $CRAFT_OVERLAY \

--- a/rocks/heat-consolidated/rockcraft.yaml
+++ b/rocks/heat-consolidated/rockcraft.yaml
@@ -22,7 +22,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42418 --system heat
       useradd \
         --gid 42418 \
-        --uid 42418  \
+        --uid 42418 \
         --no-create-home \
         --home /var/lib/heat \
         --root $CRAFT_OVERLAY \

--- a/rocks/heat-engine/rockcraft.yaml
+++ b/rocks/heat-engine/rockcraft.yaml
@@ -29,7 +29,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42418 --system heat
       useradd \
         --gid 42418 \
-        --uid 42418  \
+        --uid 42418 \
         --no-create-home \
         --home /var/lib/heat \
         --root $CRAFT_OVERLAY \

--- a/rocks/masakari-api/rockcraft.yaml
+++ b/rocks/masakari-api/rockcraft.yaml
@@ -21,9 +21,8 @@ services:
 
 parts:
   masakari-user:
-    plugin:
-      nil
-      # 42424:42424 for kolla compatibility
+    plugin: nil
+    # 42424:42424 for kolla compatibility
     overlay-script: |
       groupadd --root $CRAFT_OVERLAY --gid 42424 --system masakari
       useradd \
@@ -44,3 +43,6 @@ parts:
       - masakari-api
       - apache2
       - libapache2-mod-wsgi-py3
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/masakari-consolidated/rockcraft.yaml
+++ b/rocks/masakari-consolidated/rockcraft.yaml
@@ -17,7 +17,7 @@ package-repositories:
 parts:
   masakari-user:
     plugin: nil
-      # 42424:42424 for kolla compatibility
+    # 42424:42424 for kolla compatibility
     overlay-script: |
       groupadd --root $CRAFT_OVERLAY --gid 42424 --system masakari
       useradd \

--- a/rocks/masakari-engine/rockcraft.yaml
+++ b/rocks/masakari-engine/rockcraft.yaml
@@ -18,11 +18,13 @@ services:
   masakari-engine:
     override: replace
     command: masakari-engine
+    user: masakari
+    group: masakari
 
 parts:
   masakari-user:
     plugin: nil
-      # 42424:42424 for kolla compatibility
+    # 42424:42424 for kolla compatibility
     overlay-script: |
       groupadd --root $CRAFT_OVERLAY --gid 42424 --system masakari
       useradd \

--- a/rocks/masakari-monitors/rockcraft.yaml
+++ b/rocks/masakari-monitors/rockcraft.yaml
@@ -18,12 +18,13 @@ services:
   masakari-hostmonitor:
     override: replace
     command: masakari-hostmonitor
+    user: masakari
+    group: masakari
 
 parts:
   masakari-user:
-    plugin:
-      nil
-      # 42424:42424 for kolla compatibility
+    plugin: nil
+    # 42424:42424 for kolla compatibility
     overlay-script: |
       groupadd --root $CRAFT_OVERLAY --gid 42424 --system masakari
       useradd \

--- a/rocks/octavia-api/rockcraft.yaml
+++ b/rocks/octavia-api/rockcraft.yaml
@@ -27,7 +27,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42437 --system octavia
       useradd \
         --gid 42437 \
-        --uid 42437  \
+        --uid 42437 \
         --no-create-home \
         --home /var/lib/octavia \
         --root $CRAFT_OVERLAY \

--- a/rocks/octavia-consolidated/rockcraft.yaml
+++ b/rocks/octavia-consolidated/rockcraft.yaml
@@ -22,7 +22,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42437 --system octavia
       useradd \
         --gid 42437 \
-        --uid 42437  \
+        --uid 42437 \
         --no-create-home \
         --home /var/lib/octavia \
         --root $CRAFT_OVERLAY \

--- a/rocks/octavia-driver-agent/rockcraft.yaml
+++ b/rocks/octavia-driver-agent/rockcraft.yaml
@@ -29,7 +29,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42437 --system octavia
       useradd \
         --gid 42437 \
-        --uid 42437  \
+        --uid 42437 \
         --no-create-home \
         --home /var/lib/octavia \
         --root $CRAFT_OVERLAY \

--- a/rocks/octavia-housekeeping/rockcraft.yaml
+++ b/rocks/octavia-housekeeping/rockcraft.yaml
@@ -29,7 +29,7 @@ parts:
       groupadd --root $CRAFT_OVERLAY --gid 42437 --system octavia
       useradd \
         --gid 42437 \
-        --uid 42437  \
+        --uid 42437 \
         --no-create-home \
         --home /var/lib/octavia \
         --root $CRAFT_OVERLAY \


### PR DESCRIPTION
Fixes some of the lints seen in various rocks' `rockcraft.yaml` files. Additionally, the masakari rocks services are not running with the created `masakari` user, and `masakari-api` doesn't clear the `/etc/apache2/ports.conf` file.