### PR TITLE
Updates the rocks cookiecutter template

### DIFF
--- a/cookiecutter_code/rock-init.py
+++ b/cookiecutter_code/rock-init.py
@@ -41,11 +41,13 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(cookie_dir)
     packages = "sudo " + get_suggested_packages(args.rock_name)
-    cookiecutter(
-        "rock",
-        output_dir=str(output_dir),
-        extra_context={"rock_name": args.rock_name, "packages": packages},
-    )
+    service_name = args.rock_name.split("-")[0]
+    extra_context = {
+        "rock_name": args.rock_name,
+        "packages": packages,
+        "service_name": service_name,
+    }
+    cookiecutter("rock", output_dir=str(output_dir), extra_context=extra_context)
     return 0
 
 

--- a/cookiecutter_code/rock/cookiecutter.json
+++ b/cookiecutter_code/rock/cookiecutter.json
@@ -1,4 +1,10 @@
 {
     "rock_name": "",
-    "packages": ""
+    "service_name": "",
+    "userid": "",
+    "packages": "",
+    "__prompts__": {
+        "userid": "uid / gid to use for the service. Skipped if empty.",
+        "packages": "required to run the service."
+    }
 }

--- a/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
+++ b/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
@@ -15,11 +15,49 @@ package-repositories:
     priority: always
 
 services:
+  {%- if "apache2" in cookiecutter.packages.split() %}
   wsgi-{{ cookiecutter.rock_name }}:
     override: replace
     command: apachectl -D FOREGROUND
+  {%- else %}
+  {{ cookiecutter.rock_name }}:
+    override: replace
+    command: {{ cookiecutter.rock_name }}
+    {%- if cookiecutter.userid != "" %}
+    user: {{ cookiecutter.service_name }}
+    group: {{ cookiecutter.service_name }}
+    {%- endif %}
+  {%- endif %}
 
 parts:
-  {{ cookiecutter.rock_name }}:
+  {%- if cookiecutter.userid != "" %}
+  {{ cookiecutter.service_name }}-user:
     plugin: nil
-    overlay-packages: {{ cookiecutter.packages.split() | tojson }}
+    # {{ cookiecutter.userid }}:{{ cookiecutter.userid }} for kolla compatibility
+    overlay-script: |
+      groupadd --root $CRAFT_OVERLAY --gid {{ cookiecutter.userid }} --system {{ cookiecutter.service_name }}
+      useradd \
+        --gid {{ cookiecutter.userid }} \
+        --uid {{ cookiecutter.userid }} \
+        --no-create-home \
+        --home /var/lib/{{ cookiecutter.service_name }} \
+        --root $CRAFT_OVERLAY \
+        --system \
+        --shell /bin/false \
+        {{ cookiecutter.service_name }}
+  {%- endif %}
+
+  {{ cookiecutter.rock_name }}:
+    {% if cookiecutter.userid != "" -%}
+    after: [{{ cookiecutter.service_name }}-user]
+    {% endif -%}
+    plugin: nil
+    overlay-packages:
+      {%- for item in cookiecutter.packages.split() %}
+      - {{ item }}
+      {%- endfor %}
+    {%- if "apache2" in cookiecutter.packages.split() %}
+    override-prime: |
+      craftctl default
+      echo > $CRAFT_PRIME/etc/apache2/ports.conf
+    {%- endif %}


### PR DESCRIPTION
Adds the optional `component-user` part in the `rockcraft.yaml` file, which creates the user for kolla compatibility, as seen in various rocks.

Updates the `rockcraft.yaml`'s service to create a `wsgi-rock-name` service if it's for API rocks, or another service using `rock-name` as the service command.