### PR TITLE
[backport] Add libapache2-mod-oauth2 to keystone

### DIFF
--- a/rocks/keystone/rockcraft.yaml
+++ b/rocks/keystone/rockcraft.yaml
@@ -39,6 +39,7 @@ parts:
       - libapache2-mod-auth-gssapi
       - libapache2-mod-auth-mellon
       - libapache2-mod-auth-openidc
+      - libapache2-mod-oauth2
       - python3-ldappool
       - python3-requests-kerberos
     override-prime: |


### PR DESCRIPTION
The libapache2-mod-oauth2 module is needed when implementing a multi openid IDP setup, in conjunction with AuthType auth-openidc. That flow does not properly fetch the verification keys for JWT token validation from the jwks_uri. We can work around this limitation by using the OAuth2TokenVerify option from mod-oauth2.

The openid-connect auth type does not have this limitation.