### PR TITLE
[magnum] Add magnum-capi-helm driver

### DIFF
--- a/rocks/magnum-api/rockcraft.yaml
+++ b/rocks/magnum-api/rockcraft.yaml
@@ -37,12 +37,32 @@ parts:
 
   magnum-api:
     after: [magnum-user]
-    plugin: nil
+    plugin: python
+    source: https://opendev.org/openstack/magnum-capi-helm.git
+    source-tag: 1.2.1
+    stage-packages:
+      - python3-venv
     overlay-packages:
       - sudo
       - apache2
       - libapache2-mod-wsgi-py3
       - magnum-api
+    override-pull: |
+      craftctl default
+      rm $CRAFT_PART_SRC/requirements.txt
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf
+
+      # The plugin package installs magnum-capi-helm in
+      # $CRAFT_PRIME/bin $CRAFT_PRIME/lib/
+      # So the base ubuntu core bin and lib folder are
+      # overridden.
+      # Workaround to avoid the above situation
+      # Moving python package to dist-packages also ensure
+      # entry_points to be discovered
+      cp -rf $CRAFT_PRIME/bin/* $CRAFT_PRIME/usr/bin/
+      cp -rf $CRAFT_PRIME/lib/python3.12/site-packages/magnum_capi_helm* $CRAFT_PRIME/usr/lib/python3/dist-packages/
+      rm -rf $CRAFT_PRIME/bin
+      rm -rf $CRAFT_PRIME/lib
+      rm -rf $CRAFT_PRIME/lib64

--- a/rocks/magnum-conductor/rockcraft.yaml
+++ b/rocks/magnum-conductor/rockcraft.yaml
@@ -39,7 +39,34 @@ parts:
 
   magnum-conductor:
     after: [magnum-user]
-    plugin: nil
+    plugin: python
+    source: https://opendev.org/openstack/magnum-capi-helm.git
+    source-tag: 1.2.1
+    stage-packages:
+      - python3-venv
+    stage-snaps:
+      - helm/latest/stable
     overlay-packages:
       - sudo
       - magnum-conductor
+    override-pull: |
+      craftctl default
+      rm $CRAFT_PART_SRC/requirements.txt
+    override-prime: |
+      craftctl default
+
+      # The plugin package installs magnum-capi-helm in
+      # $CRAFT_PRIME/bin $CRAFT_PRIME/lib/
+      # So the base ubuntu core bin and lib folder are
+      # overridden.
+      # Workaround to avoid the above situation
+      # Moving python package to dist-packages also ensure
+      # entry_points to be discovered
+      cp -rf $CRAFT_PRIME/bin/* $CRAFT_PRIME/usr/bin/
+      cp -rf $CRAFT_PRIME/lib/python3.12/site-packages/magnum_capi_helm* $CRAFT_PRIME/usr/lib/python3/dist-packages/
+      rm -rf $CRAFT_PRIME/bin
+      rm -rf $CRAFT_PRIME/lib
+      rm -rf $CRAFT_PRIME/lib64
+
+      # Move helm package to bin
+      mv $CRAFT_PRIME/helm $CRAFT_PRIME/usr/bin/

--- a/rocks/magnum-consolidated/rockcraft.yaml
+++ b/rocks/magnum-consolidated/rockcraft.yaml
@@ -32,13 +32,38 @@ parts:
 
   magnum-consolidated:
     after: [magnum-user]
-    plugin: nil
+    plugin: python
+    source: https://opendev.org/openstack/magnum-capi-helm.git
+    source-tag: 1.2.1
+    stage-packages:
+      - python3-venv
+    stage-snaps:
+      - helm/latest/stable
     overlay-packages:
       - sudo
       - apache2
       - libapache2-mod-wsgi-py3
       - magnum-api
       - magnum-conductor
+    override-pull: |
+      craftctl default
+      rm $CRAFT_PART_SRC/requirements.txt
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf
+
+      # The plugin package installs magnum-capi-helm in
+      # $CRAFT_PRIME/bin $CRAFT_PRIME/lib/
+      # So the base ubuntu core bin and lib folder are
+      # overridden.
+      # Workaround to avoid the above situation
+      # Moving python package to dist-packages also ensure
+      # entry_points to be discovered
+      cp -rf $CRAFT_PRIME/bin/* $CRAFT_PRIME/usr/bin/
+      cp -rf $CRAFT_PRIME/lib/python3.12/site-packages/magnum_capi_helm* $CRAFT_PRIME/usr/lib/python3/dist-packages/
+      rm -rf $CRAFT_PRIME/bin
+      rm -rf $CRAFT_PRIME/lib
+      rm -rf $CRAFT_PRIME/lib64
+
+      # Move helm package to bin
+      mv $CRAFT_PRIME/helm $CRAFT_PRIME/usr/bin/


### PR DESCRIPTION
Add magnum-capi-helm driver from github
repo. Dont install requiements.txt as this
will trigger installing magnum from pypi
with latest version.

Workaround to move python packages to necessary
locations for discovery of driver and remove
unnecessary files so that overlay from core
image are not overlapped.