### PR TITLE
fix: update to cloudkitty 22.x from flamingo

### DIFF
--- a/rocks/cloudkitty-api/rockcraft.yaml
+++ b/rocks/cloudkitty-api/rockcraft.yaml
@@ -11,7 +11,9 @@ platforms:
 
 package-repositories:
   - type: apt
-    cloud: epoxy
+    # Take flamingo package for now as per
+    # https://releases.openstack.org/teams/cloudkitty.html
+    cloud: flamingo
     priority: always
 
 services:

--- a/rocks/cloudkitty-consolidated/rockcraft.yaml
+++ b/rocks/cloudkitty-consolidated/rockcraft.yaml
@@ -11,7 +11,9 @@ platforms:
 
 package-repositories:
   - type: apt
-    cloud: epoxy
+    # Take flamingo package for now as per
+    # https://releases.openstack.org/teams/cloudkitty.html
+    cloud: flamingo
     priority: always
 
 parts:

--- a/rocks/cloudkitty-processor/rockcraft.yaml
+++ b/rocks/cloudkitty-processor/rockcraft.yaml
@@ -11,7 +11,9 @@ platforms:
 
 package-repositories:
   - type: apt
-    cloud: epoxy
+    # Take flamingo package for now as per
+    # https://releases.openstack.org/teams/cloudkitty.html
+    cloud: flamingo
     priority: always
 
 services:


### PR DESCRIPTION
Due to unsolved pythonic issues with cloudkitty 21.x which appear to be related to this commit - https://github.com/openstack/cloudkitty/commit/e51ffa9d87b40ead433ae63589091500f6d9a8ca I'd like to propose moving to 22.x from the Flamingo repo. 

The commit is in 22.x which is the version for Epoxy/Flamingo as per https://releases.openstack.org/teams/cloudkitty.html, so this shouldn't pose a problem.