### PR TITLE
[openstack-images-sync] Remove ports.conf in overlay

### DIFF
--- a/rocks/openstack-images-sync/rockcraft.yaml
+++ b/rocks/openstack-images-sync/rockcraft.yaml
@@ -27,6 +27,8 @@ parts:
     plugin: nil
     overlay-packages:
       - apache2
+    overlay-script: |
+      rm ${CRAFT_OVERLAY}/etc/apache2/ports.conf
     override-prime: |
       craftctl default
       mkdir -p $CRAFT_PRIME/etc/apache2/


### PR DESCRIPTION
ports.conf has the default configuration instead of empty file. This breaks http-sync since the service is also trying to run on port 80 which is already
defined in ports.conf

Remove ports.conf as part of overlay-script