### PR TITLE
ironic: Adds novnc package to ironic-novncproxy and ironic-consolidated

### DIFF
--- a/rocks/ironic-consolidated/rockcraft.yaml
+++ b/rocks/ironic-consolidated/rockcraft.yaml
@@ -38,6 +38,7 @@ parts:
       - apache2
       - libapache2-mod-wsgi-py3
       - ironic-api
+      - novnc
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/ironic-novncproxy/rockcraft.yaml
+++ b/rocks/ironic-novncproxy/rockcraft.yaml
@@ -44,6 +44,7 @@ parts:
       - sudo
       # ironic-api contains ironic-novncproxy
       - ironic-api
+      - novnc
     prime:
       - usr/bin/ironic-rootwrap
       - usr/bin/ironic-novncproxy


### PR DESCRIPTION
The package is required by `ironic-novncproxy`.