### PR TITLE
rocks: add shell tools and /bin symlinks to bare CNI rocks

### DIFF
--- a/rocks/openstack-port-cni/rockcraft.yaml
+++ b/rocks/openstack-port-cni/rockcraft.yaml
@@ -15,6 +15,23 @@ platforms:
   arm64:
 
 parts:
+  shell-tools:
+    plugin: nil
+    stage-packages:
+      - dash_bins
+      - coreutils_bins
+    override-prime: |
+      craftctl default
+      # Chisel places binaries under usr/bin/ but bare rocks have no usrmerge
+      # bin->usr/bin symlink. Unlike ovs-cni-plugin (where override-build puts
+      # binaries at the root of CRAFT_PART_INSTALL), the go plugin here outputs
+      # to bin/, and openstack-port-daemon remains there after organize moves
+      # openstack-port-cni to opt/cni/bin/. Because bin/ exists as a real
+      # directory, we cannot replace it with a symlink, so create individual
+      # symlinks for /bin/sh and /bin/cp instead.
+      ln -sf ../usr/bin/dash $CRAFT_PRIME/bin/sh
+      ln -sf ../usr/bin/cp $CRAFT_PRIME/bin/cp
+
   openstack-port-cni:
     plugin: go
     source: https://github.com/canonical/openstack-port-cni

--- a/rocks/ovs-cni-plugin/rockcraft.yaml
+++ b/rocks/ovs-cni-plugin/rockcraft.yaml
@@ -14,6 +14,18 @@ platforms:
   arm64:
 
 parts:
+  shell-tools:
+    plugin: nil
+    stage-packages:
+      - dash_bins
+      - coreutils_bins
+      - findutils_bins
+      - grep_bins
+    override-prime: |
+      craftctl default
+      ln -sf usr/bin $CRAFT_PRIME/bin
+      mkdir -p $CRAFT_PRIME/tmp
+
   ovs-cni:
     plugin: go
     # TODO: Switch to upstream once https://github.com/k8snetworkplumbingwg/ovs-cni/pull/424 is merged and released


### PR DESCRIPTION
Both ovs-cni-plugin and openstack-port-cni are bare rocks and lack /bin/sh, /bin/cp and other utilities required at runtime.

For ovs-cni-plugin:
- Stage dash_bins, coreutils_bins, findutils_bins and grep_bins chisel slices (find/grep are needed by the marker liveness/readiness probe)
- Symlink bin -> usr/bin since bin/ does not exist as a real directory
- Create /tmp so the marker binary can write its health file

For openstack-port-cni:
- Stage dash_bins and coreutils_bins chisel slices
- Create individual bin/sh and bin/cp symlinks; bin/ already exists as a real directory (openstack-port-daemon is placed there by the go plugin), so a directory-level symlink is not possible