### PR TITLE
Add openvswitch-common to neutron-api/consolidated rocks

### DIFF
--- a/rocks/neutron-api/rockcraft.yaml
+++ b/rocks/neutron-api/rockcraft.yaml
@@ -46,6 +46,7 @@ parts:
       - python3-oslo.vmware
       - apache2
       - libapache2-mod-wsgi-py3
+      - openvswitch-common
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/neutron-consolidated/rockcraft.yaml
+++ b/rocks/neutron-consolidated/rockcraft.yaml
@@ -43,6 +43,7 @@ parts:
       - python3-oslo.vmware
       - apache2
       - libapache2-mod-wsgi-py3
+      - openvswitch-common
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf


### PR DESCRIPTION
The neutron-api package now runs under apache+mod_wsgi instead of as a standalone neutron-server process. When mod_wsgi imports the WSGI application, neutron.server.api publishes a PROCESS/BEFORE_SPAWN event on every worker fork, which triggers OVNMechanismDriver.pre_fork_initialize. That callback shells out to ovsdb-client which was missing previously.