### PR TITLE
fix: grant package write for publish callers

### DIFF
--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -38,6 +38,9 @@ jobs:
           echo "rocks=$all_rocks" >> $GITHUB_OUTPUT
   build-and-publish:
     needs: allrocks
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build_publish.yaml
     with:
       rocks: ${{ needs.allrocks.outputs.rocks }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,9 +7,14 @@ jobs:
   modified_rocks:
     uses: ./.github/workflows/modified_rocks.yaml
 
-  build-and-publish:
+  build:
+    name: Build rock
     needs: modified_rocks
-    uses: ./.github/workflows/build_publish.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        rock: ${{ fromJson(needs.modified_rocks.outputs.rocks) }}
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
     with:
-      rocks: ${{ needs.modified_rocks.outputs.rocks }}
-      publish: false
+      path-to-rock-directory: rocks/${{ matrix.rock }}
+      artifact-prefix: packed-rock-${{ matrix.rock }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,6 +14,9 @@ jobs:
 
   build-and-publish:
     needs: modified_rocks
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build_publish.yaml
     with:
       rocks: ${{ needs.modified_rocks.outputs.rocks }}


### PR DESCRIPTION
Grant package write access only to workflows that publish ROCKs, and keep pull request builds on the build-only reusable workflow.
    
The publish reusable workflow references the release workflow, so pull request startup validation fails even when publish is false.