### PR TITLE
feat: Move base back to 24.04, source from UCA

### DIFF
--- a/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
+++ b/cookiecutter_code/rock/{{cookiecutter.rock_name}}/rockcraft.yaml
@@ -4,9 +4,9 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack {{ cookiecutter.rock_name }}
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
 

--- a/rocks/aodh-api/rockcraft.yaml
+++ b/rocks/aodh-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack aodh-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-aodh-api:

--- a/rocks/aodh-consolidated/rockcraft.yaml
+++ b/rocks/aodh-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of AODH which can be used for all AODH services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   aodh-user:

--- a/rocks/aodh-evaluator/rockcraft.yaml
+++ b/rocks/aodh-evaluator/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack aodh-evaluator
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   aodh-evaluator:

--- a/rocks/aodh-expirer/rockcraft.yaml
+++ b/rocks/aodh-expirer/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack aodh-expirer
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   aodh-expirer:

--- a/rocks/aodh-listener/rockcraft.yaml
+++ b/rocks/aodh-listener/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack aodh-listener
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   aodh-listener:

--- a/rocks/aodh-notifier/rockcraft.yaml
+++ b/rocks/aodh-notifier/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack aodh-notifier
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   aodh-notifier:

--- a/rocks/barbican-api/rockcraft.yaml
+++ b/rocks/barbican-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack barbican-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-barbican-api:

--- a/rocks/barbican-consolidated/rockcraft.yaml
+++ b/rocks/barbican-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack barbican-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   barbican-user:

--- a/rocks/barbican-worker/rockcraft.yaml
+++ b/rocks/barbican-worker/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack barbican-worker
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   barbican-worker:

--- a/rocks/ceilometer-central/rockcraft.yaml
+++ b/rocks/ceilometer-central/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ceilometer-central
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   ceilometer-central:

--- a/rocks/ceilometer-consolidated/rockcraft.yaml
+++ b/rocks/ceilometer-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ceilometer-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   ceilometer-user:

--- a/rocks/ceilometer-notification/rockcraft.yaml
+++ b/rocks/ceilometer-notification/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ceilometer-notification
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   ceilometer-notification:

--- a/rocks/cinder-api/rockcraft.yaml
+++ b/rocks/cinder-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack cinder-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-cinder-api:

--- a/rocks/cinder-consolidated/rockcraft.yaml
+++ b/rocks/cinder-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of Cinder which can be used for all Cinder services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   cinder-user:

--- a/rocks/cinder-scheduler/rockcraft.yaml
+++ b/rocks/cinder-scheduler/rockcraft.yaml
@@ -5,12 +5,17 @@ description: |
   Ubuntu distribution of OpenStack cinder-scheduler
 version: "2026.1"
 
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   cinder-scheduler:

--- a/rocks/cinder-volume/rockcraft.yaml
+++ b/rocks/cinder-volume/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack cinder-volume
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   cinder-volume:

--- a/rocks/cloudkitty-api/rockcraft.yaml
+++ b/rocks/cloudkitty-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack cloudkitty-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-cloudkitty-api:

--- a/rocks/cloudkitty-consolidated/rockcraft.yaml
+++ b/rocks/cloudkitty-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack cloudkitty-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   cloudkitty-user:

--- a/rocks/cloudkitty-processor/rockcraft.yaml
+++ b/rocks/cloudkitty-processor/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack cloudkitty-processor
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   cloudkitty-processor:

--- a/rocks/consul/rockcraft.yaml
+++ b/rocks/consul/rockcraft.yaml
@@ -5,7 +5,9 @@ description: |
   Ubuntu distribution of Hashicorp Consul
 version: "1.19.2"
 base: bare
-build-base: devel
+# renovate: build-base: ubuntu:26.04@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573
+build-base: ubuntu@26.04
+
 platforms:
   amd64:
   arm64:

--- a/rocks/designate-api/rockcraft.yaml
+++ b/rocks/designate-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack designate-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-designate-api:

--- a/rocks/designate-central/rockcraft.yaml
+++ b/rocks/designate-central/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack designate-central
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   designate-central:

--- a/rocks/designate-consolidated/rockcraft.yaml
+++ b/rocks/designate-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack designate-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   designate-user:

--- a/rocks/designate-mdns/rockcraft.yaml
+++ b/rocks/designate-mdns/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack designate-mdns
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   designate-mdns:

--- a/rocks/designate-producer/rockcraft.yaml
+++ b/rocks/designate-producer/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack designate-producer
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   designate-producer:

--- a/rocks/designate-worker/rockcraft.yaml
+++ b/rocks/designate-worker/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack designate-worker
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   designate-worker:

--- a/rocks/glance-api/rockcraft.yaml
+++ b/rocks/glance-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack glance-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   glance-api:

--- a/rocks/gnocchi-api/rockcraft.yaml
+++ b/rocks/gnocchi-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack gnocchi-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-gnocchi-api:

--- a/rocks/gnocchi-consolidated/rockcraft.yaml
+++ b/rocks/gnocchi-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack gnocchi which can be used for all gnocchi services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   gnocchi-user:

--- a/rocks/gnocchi-metricd/rockcraft.yaml
+++ b/rocks/gnocchi-metricd/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack gnocchi-metricd
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   gnocchi-metricd:

--- a/rocks/heat-api/rockcraft.yaml
+++ b/rocks/heat-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack heat-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   heat-user:

--- a/rocks/heat-consolidated/rockcraft.yaml
+++ b/rocks/heat-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Heat which can be used for all Heat services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   heat-user:

--- a/rocks/heat-engine/rockcraft.yaml
+++ b/rocks/heat-engine/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack heat-engine
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   heat-engine:

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -47,7 +47,7 @@ parts:
       - python3-designate-dashboard
       - python3-mysqldb
       # Horizon plugins needing manual management
-      - python3-heat-dashboard
+      # - python3-heat-dashboard # disabled LP#2155142
       - python3-magnum-ui
       - python3-manila-ui
       - python3-octavia-dashboard
@@ -93,6 +93,8 @@ parts:
       _1630_project_resource_types_panel.py
       _1640_project_template_versions_panel.py
       _1650_project_template_generator_panel.py" > $CRAFT_STAGE/$AVAILABLE/heat
+      # TODO: remove the following line when LP#2155142 is resolved.
+      echo "" > $CRAFT_STAGE/$AVAILABLE/heat
       echo "_31000_goals_panel.py
       _31010_strategies_panel.py
       _31020_watcher_panelgroup.py

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -104,15 +104,15 @@ parts:
       _31040_audits_panel.py
       _31050_action_plans_panel.py
       _31060_actions_panel.py" > $CRAFT_STAGE/$AVAILABLE/watcher
-      echo "_10_admin_group.py
-      _10_project_group.py
-      _11_admin_hashmap_panel.py
-      _11_admin_rating_panel.py
-      _11_admin_summary_panel.py
-      _11_project_rating_panel.py
-      _12_project_reporting_panel.py
-      _13_admin_pyscripts_panel.py
-      _31000_cloudkitty.py" > $CRAFT_STAGE/$AVAILABLE/cloudkitty
+      echo "_32010_admin_group.py
+      _32011_project_group.py
+      _32020_admin_hashmap_panel.py
+      _32021_admin_rating_panel.py
+      _32022_admin_summary_panel.py
+      _32030_project_rating_panel.py
+      _32031_project_reporting_panel.py
+      _32040_admin_pyscripts_panel.py
+      _32050_cloudkitty.py" > $CRAFT_STAGE/$AVAILABLE/cloudkitty
     override-prime: |
       craftctl default
 

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack horizon
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-horizon:

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -48,7 +48,7 @@ parts:
       - python3-mysqldb
       # Horizon plugins needing manual management
       # - python3-heat-dashboard # disabled LP#2155142
-      - python3-magnum-ui
+      # - python3-magnum-ui # disabled LP#2155145
       - python3-manila-ui
       - python3-octavia-dashboard
       - python3-watcher-dashboard
@@ -66,6 +66,8 @@ parts:
       _1372_project_container_infra_cluster_templates_panel.py
       _2370_admin_container_infra_panel_group.py
       _2371_admin_container_infra_quotas_panel.py" > $CRAFT_STAGE/$AVAILABLE/magnum
+      # TODO: remove the following line when LP#2155145 is resolved.
+      echo "" > $CRAFT_STAGE/$AVAILABLE/magnum
       echo "_80_manila_admin_add_share_panel_group.py
       _80_manila_project_add_share_panel_group.py
       _9010_manila_admin_add_shares_panel_to_share_panel_group.py

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -123,6 +123,11 @@ parts:
         echo "Processing $plugin_file"
         cp $CRAFT_STAGE/$AVAILABLE/$plugin_file $CRAFT_PRIME/$AVAILABLE/$plugin_file
         while read line; do
+          # Skip empty lines when a dashboard is emptied out for workaround
+          if [[ -z "$line" ]]; then
+            continue
+          fi
+
           enable_file=$CRAFT_PRIME/$ENABLED/$line
           local_enable_file=$CRAFT_PRIME/$LOCAL_ENABLED/$line
           available_file=$CRAFT_PRIME/$AVAILABLE/$line

--- a/rocks/ironic-api/rockcraft.yaml
+++ b/rocks/ironic-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ironic-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-ironic-api:

--- a/rocks/ironic-conductor/rockcraft.yaml
+++ b/rocks/ironic-conductor/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ironic-conductor
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   ironic-conductor:

--- a/rocks/ironic-consolidated/rockcraft.yaml
+++ b/rocks/ironic-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Ironic services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   ironic-user:

--- a/rocks/ironic-novncproxy/rockcraft.yaml
+++ b/rocks/ironic-novncproxy/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ironic-novncproxy
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   ironic-novncproxy:

--- a/rocks/keystone/rockcraft.yaml
+++ b/rocks/keystone/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack keystone
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-keystone:

--- a/rocks/magnum-api/rockcraft.yaml
+++ b/rocks/magnum-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack magnum-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-magnum-api:

--- a/rocks/magnum-conductor/rockcraft.yaml
+++ b/rocks/magnum-conductor/rockcraft.yaml
@@ -4,14 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack magnum-conductor
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
 
 package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
   - type: apt
     ppa: canonical-openstack/magnum-capi-helm
 

--- a/rocks/magnum-consolidated/rockcraft.yaml
+++ b/rocks/magnum-consolidated/rockcraft.yaml
@@ -4,14 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack magnum-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
 
 package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
   - type: apt
     ppa: canonical-openstack/magnum-capi-helm
 

--- a/rocks/manila-api/rockcraft.yaml
+++ b/rocks/manila-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack manila-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-manila-api:

--- a/rocks/manila-consolidated/rockcraft.yaml
+++ b/rocks/manila-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Manila which can be used for all manila services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   manila-user:

--- a/rocks/manila-scheduler/rockcraft.yaml
+++ b/rocks/manila-scheduler/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack manila-scheduler
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   manila-scheduler:

--- a/rocks/manila-share/rockcraft.yaml
+++ b/rocks/manila-share/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack manila-share
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   manila-share:

--- a/rocks/masakari-api/rockcraft.yaml
+++ b/rocks/masakari-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack masakari-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-masakari-api:

--- a/rocks/masakari-consolidated/rockcraft.yaml
+++ b/rocks/masakari-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack masakari-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   masakari-user:

--- a/rocks/masakari-engine/rockcraft.yaml
+++ b/rocks/masakari-engine/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack masakari-engine
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   masakari-engine:

--- a/rocks/masakari-monitors/rockcraft.yaml
+++ b/rocks/masakari-monitors/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack masakari monitors
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   masakari-hostmonitor:

--- a/rocks/neutron-api/rockcraft.yaml
+++ b/rocks/neutron-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack neutron-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-neutron-api:

--- a/rocks/neutron-consolidated/rockcraft.yaml
+++ b/rocks/neutron-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Neutron which can be used for all Neutron services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   neutron-user:

--- a/rocks/neutron-periodic-workers/rockcraft.yaml
+++ b/rocks/neutron-periodic-workers/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack neutron-periodic-workers
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   neutron-periodic-workers:

--- a/rocks/neutron-rpc-server/rockcraft.yaml
+++ b/rocks/neutron-rpc-server/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack neutron-rpc-server
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   neutron-rpc-server:

--- a/rocks/nova-api/rockcraft.yaml
+++ b/rocks/nova-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack nova-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-nova-api:

--- a/rocks/nova-conductor/rockcraft.yaml
+++ b/rocks/nova-conductor/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack nova-conductor
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   nova-conductor:

--- a/rocks/nova-consolidated/rockcraft.yaml
+++ b/rocks/nova-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of Nova which can be used for all Nova services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   nova-user:

--- a/rocks/nova-ironic/rockcraft.yaml
+++ b/rocks/nova-ironic/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack nova-ironic
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   nova-ironic:

--- a/rocks/nova-scheduler/rockcraft.yaml
+++ b/rocks/nova-scheduler/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack nova-scheduler
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   nova-scheduler:

--- a/rocks/nova-spiceproxy/rockcraft.yaml
+++ b/rocks/nova-spiceproxy/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack nova-spiceproxy
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   nova-spiceproxy:

--- a/rocks/octavia-api/rockcraft.yaml
+++ b/rocks/octavia-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack octavia-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-octavia-api:

--- a/rocks/octavia-consolidated/rockcraft.yaml
+++ b/rocks/octavia-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack octavia-consolidated
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   octavia-user:

--- a/rocks/octavia-driver-agent/rockcraft.yaml
+++ b/rocks/octavia-driver-agent/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack octavia-driver-agent
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   octavia-driver-agent:

--- a/rocks/octavia-housekeeping/rockcraft.yaml
+++ b/rocks/octavia-housekeeping/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack octavia-housekeeping
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   octavia-housekeeping:

--- a/rocks/openstack-exporter/rockcraft.yaml
+++ b/rocks/openstack-exporter/rockcraft.yaml
@@ -6,8 +6,9 @@ description: |
 version: 1.7.0-3be9ddb
 
 base: bare
-# renovate: build-base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-build-base: devel
+# renovate: build-base: ubuntu:26.04@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573
+build-base: ubuntu@26.04
+
 run-user: _daemon_
 platforms:
   amd64:

--- a/rocks/openstack-images-sync/rockcraft.yaml
+++ b/rocks/openstack-images-sync/rockcraft.yaml
@@ -5,9 +5,9 @@ description: >-
   Openstack Images Sync is a tool allowing synchronization
   from a list of SimpleStreams source to an OpenStack cloud.
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:

--- a/rocks/openstack-port-cni/rockcraft.yaml
+++ b/rocks/openstack-port-cni/rockcraft.yaml
@@ -8,8 +8,9 @@ description: |
 version: "0.1.0-127cdfa-devel"
 
 base: bare
-# renovate: build-base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-build-base: devel
+# renovate: build-base: ubuntu:26.04@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573
+build-base: ubuntu@26.04
+
 platforms:
   amd64:
   arm64:

--- a/rocks/ovn-consolidated/rockcraft.yaml
+++ b/rocks/ovn-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OVN which can be used for all OVN services
 version: "26.03"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   ovn-consolidated:

--- a/rocks/ovn-nb-db-server/rockcraft.yaml
+++ b/rocks/ovn-nb-db-server/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ovn-nb-db-server
 version: "26.03"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   ovn-nb-db-server:

--- a/rocks/ovn-northd/rockcraft.yaml
+++ b/rocks/ovn-northd/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ovn-northd
 version: "26.03"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   ovn-northd:

--- a/rocks/ovn-sb-db-server/rockcraft.yaml
+++ b/rocks/ovn-sb-db-server/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack ovn-sb-db-server
 version: "26.03"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   ovn-sb-db-server:

--- a/rocks/ovs-cni-plugin/rockcraft.yaml
+++ b/rocks/ovs-cni-plugin/rockcraft.yaml
@@ -7,8 +7,9 @@ description: |
 version: "0.1.0-107d5dd-devel"
 
 base: bare
-# renovate: build-base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-build-base: devel
+# renovate: build-base: ubuntu:26.04@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573
+build-base: ubuntu@26.04
+
 platforms:
   amd64:
   arm64:

--- a/rocks/placement-api/rockcraft.yaml
+++ b/rocks/placement-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack placement-api
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-placement-api:

--- a/rocks/rabbitmq/rockcraft.yaml
+++ b/rocks/rabbitmq/rockcraft.yaml
@@ -2,9 +2,9 @@ name: rabbitmq
 summary: RabbitMQ
 description: AMQP based message broker.
 version: "3.12.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 license: Apache-2.0
 platforms:
   amd64:

--- a/rocks/skyline-apiserver/rockcraft.yaml
+++ b/rocks/skyline-apiserver/rockcraft.yaml
@@ -4,9 +4,9 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack skyline-apiserver
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:

--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -8,9 +8,9 @@ description: |
   deployment. This ROCK is built using the snap-tempest.
 version: "2026.1"
 
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:

--- a/rocks/watcher-api/rockcraft.yaml
+++ b/rocks/watcher-api/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher API service
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   wsgi-watcher-api:

--- a/rocks/watcher-applier/rockcraft.yaml
+++ b/rocks/watcher-applier/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher applier service
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   watcher-applier:

--- a/rocks/watcher-consolidated/rockcraft.yaml
+++ b/rocks/watcher-consolidated/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher which can be used for all watcher services
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 parts:
   watcher-user:

--- a/rocks/watcher-decision-engine/rockcraft.yaml
+++ b/rocks/watcher-decision-engine/rockcraft.yaml
@@ -4,12 +4,17 @@ license: Apache-2.0
 description: |
   Ubuntu distribution of OpenStack Watcher decision engine service
 version: "2026.1"
-# renovate: base: ubuntu:26.04@sha256:fed6ddb82c61194e1814e93b59cfcb6759e5aa33c4e41bb3782313c2386ed6df
-base: ubuntu@26.04
-build-base: devel
+# renovate: base: ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11
+base: ubuntu@24.04
+
 platforms:
   amd64:
   arm64:
+
+package-repositories:
+  - type: apt
+    cloud: gazpacho
+    priority: always
 
 services:
   watcher-decision-engine:


### PR DESCRIPTION
For the gazpacho release, we're moving back to 24.04 because of the GC change that brings instability in the new Python version.

Ensure bare bases use the 26.04 base instead of devel. bare rocks are go projects, and are unaffected by the new python GC issue.

Related-Bug: #2154897