### PR TITLE
feat(openstack-port-cni): Update source commit

### DIFF
--- a/rocks/openstack-port-cni/rockcraft.yaml
+++ b/rocks/openstack-port-cni/rockcraft.yaml
@@ -5,7 +5,7 @@ description: |
   A CNI plugin that wraps ovs-cni with OpenStack Neutron port management.
   Uses a thin/thick architecture where a lightweight CNI binary delegates
   OpenStack operations to a daemon over a Unix domain socket.
-version: "0.1.0-127cdfa-devel"
+version: "0.1.0-7d0a487-devel"
 
 base: bare
 # renovate: build-base: ubuntu:26.04@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573
@@ -36,7 +36,7 @@ parts:
   openstack-port-cni:
     plugin: go
     source: https://github.com/canonical/openstack-port-cni
-    source-commit: 127cdfade20862cce9ef7f8b9568c08cbabe8356
+    source-commit: 7d0a48762ebae518377ca1918a26bda1cb6c04c1
     source-type: git
     source-depth: 1
     build-environment:


### PR DESCRIPTION
Update source commit to
https://github.com/canonical/openstack-port-cni/commit/7d0a48762ebae518377ca1918a26bda1cb6c04c1 to get latest changes related to CACERT fixes

Related-Fix: https://bugs.launchpad.net/snap-openstack/+bug/2155113