### PR TITLE
feat: include nova-api-metadata

### DIFF
--- a/rocks/nova-api/rockcraft.yaml
+++ b/rocks/nova-api/rockcraft.yaml
@@ -43,6 +43,7 @@ parts:
     overlay-packages:
       - sudo
       - nova-api
+      - nova-api-metadata
       - apache2
       - libapache2-mod-wsgi-py3
     override-prime: |

--- a/rocks/nova-consolidated/rockcraft.yaml
+++ b/rocks/nova-consolidated/rockcraft.yaml
@@ -38,6 +38,7 @@ parts:
     overlay-packages:
       - sudo
       - nova-api
+      - nova-api-metadata
       - nova-conductor
       - nova-scheduler
       - nova-spiceproxy


### PR DESCRIPTION
From 2026.1 and onward, nova-api-metadata lives in the nova-k8s application.