### PR TITLE
Add s390x support to rocks and update workflow pinning

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -21,10 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(inputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@main
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}
+    permissions:
+      actions: read  # Needed by build_rock.yaml to look up the workflow version
+      contents: read
 
   publish:
     if: ${{ inputs.publish }}
@@ -33,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(inputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@main
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(needs.modified_rocks.outputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@main
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}
+    permissions:
+      actions: read  # Needed by build_rock.yaml to look up the workflow version
+      contents: read

--- a/.github/workflows/security-compliance.yaml
+++ b/.github/workflows/security-compliance.yaml
@@ -137,10 +137,13 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(needs.list-rocks.outputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@main
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}
+    permissions:
+      actions: read  # Needed by build_rock.yaml to look up the workflow version
+      contents: read
 
   secscan:
     name: Secscan ${{ matrix.rock }}

--- a/rocks/aodh-consolidated/rockcraft.yaml
+++ b/rocks/aodh-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/barbican-consolidated/rockcraft.yaml
+++ b/rocks/barbican-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/ceilometer-consolidated/rockcraft.yaml
+++ b/rocks/ceilometer-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/cinder-consolidated/rockcraft.yaml
+++ b/rocks/cinder-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/cloudkitty-consolidated/rockcraft.yaml
+++ b/rocks/cloudkitty-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/consul/rockcraft.yaml
+++ b/rocks/consul/rockcraft.yaml
@@ -11,6 +11,7 @@ build-base: ubuntu@26.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 run-user: _daemon_
 

--- a/rocks/designate-consolidated/rockcraft.yaml
+++ b/rocks/designate-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/glance-api/rockcraft.yaml
+++ b/rocks/glance-api/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/gnocchi-consolidated/rockcraft.yaml
+++ b/rocks/gnocchi-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/heat-consolidated/rockcraft.yaml
+++ b/rocks/heat-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/horizon/rockcraft.yaml
+++ b/rocks/horizon/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/ironic-consolidated/rockcraft.yaml
+++ b/rocks/ironic-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/keystone/rockcraft.yaml
+++ b/rocks/keystone/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/magnum-consolidated/rockcraft.yaml
+++ b/rocks/magnum-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/manila-consolidated/rockcraft.yaml
+++ b/rocks/manila-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/masakari-consolidated/rockcraft.yaml
+++ b/rocks/masakari-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/neutron-consolidated/rockcraft.yaml
+++ b/rocks/neutron-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/nova-consolidated/rockcraft.yaml
+++ b/rocks/nova-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/octavia-consolidated/rockcraft.yaml
+++ b/rocks/octavia-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/openstack-exporter/rockcraft.yaml
+++ b/rocks/openstack-exporter/rockcraft.yaml
@@ -13,6 +13,7 @@ run-user: _daemon_
 platforms:
   amd64:
   arm64:
+  s390x:
 
 parts:
   openstack-exporter:

--- a/rocks/openstack-images-sync/rockcraft.yaml
+++ b/rocks/openstack-images-sync/rockcraft.yaml
@@ -43,6 +43,12 @@ parts:
     source-type: git
     source-depth: 1
     source-commit: 89f18a706b369892b418125fae7879e5550c4827
+    build-packages:
+      # cryptography has no prebuilt s390x wheel, so it is built from
+      # source via Rust; openssl-sys needs pkg-config and the OpenSSL
+      # headers to locate the system OpenSSL.
+      - pkg-config
+      - libssl-dev
     stage-packages:
       - python3
       - python3-venv

--- a/rocks/openstack-images-sync/rockcraft.yaml
+++ b/rocks/openstack-images-sync/rockcraft.yaml
@@ -11,6 +11,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 run-user: _daemon_
 

--- a/rocks/openstack-port-cni/rockcraft.yaml
+++ b/rocks/openstack-port-cni/rockcraft.yaml
@@ -14,6 +14,7 @@ build-base: ubuntu@26.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 parts:
   shell-tools:

--- a/rocks/ovn-consolidated/rockcraft.yaml
+++ b/rocks/ovn-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/ovn-nb-db-server/rockcraft.yaml
+++ b/rocks/ovn-nb-db-server/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/ovn-northd/rockcraft.yaml
+++ b/rocks/ovn-northd/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/ovn-sb-db-server/rockcraft.yaml
+++ b/rocks/ovn-sb-db-server/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/ovs-cni-plugin/rockcraft.yaml
+++ b/rocks/ovs-cni-plugin/rockcraft.yaml
@@ -13,6 +13,7 @@ build-base: ubuntu@26.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 parts:
   shell-tools:

--- a/rocks/placement-api/rockcraft.yaml
+++ b/rocks/placement-api/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/rocks/rabbitmq/rockcraft.yaml
+++ b/rocks/rabbitmq/rockcraft.yaml
@@ -9,6 +9,7 @@ license: Apache-2.0
 platforms:
   amd64:
   arm64:
+  s390x:
 
 services:
   rabbitmq:

--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -14,6 +14,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 parts:
   tempest-user:

--- a/rocks/watcher-consolidated/rockcraft.yaml
+++ b/rocks/watcher-consolidated/rockcraft.yaml
@@ -10,6 +10,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 package-repositories:
   - type: apt


### PR DESCRIPTION
Add s390x architecture support for all rocks excluding skyline. Also pull the build_rocks.yaml from main branch as to use the new 60 min timeout that was necessary to allow enough time for rocks to build. 