### PR TITLE
fix: pin reusable workflows to v49.0.3 and fix publish permissions

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(inputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v49.0.3
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}
@@ -36,10 +36,11 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(inputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock_edge.yaml@v49.0.3
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}
-      create-git-tags: false
     permissions:
+      actions: read  # Needed by release_rock_edge.yaml to look up the workflow version
+      contents: write  # Needed by release_rock_edge.yaml
       packages: write  # Needed to publish to GitHub Container Registry

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(needs.modified_rocks.outputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v49.0.3
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}

--- a/.github/workflows/security-compliance.yaml
+++ b/.github/workflows/security-compliance.yaml
@@ -137,7 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         rock: ${{ fromJson(needs.list-rocks.outputs.rocks) }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v49.0.3
     with:
       path-to-rock-directory: rocks/${{ matrix.rock }}
       artifact-prefix: packed-rock-${{ matrix.rock }}


### PR DESCRIPTION
The publish job referenced release_rock.yaml@main, which upstream renamed to release_rock_edge.yaml (and dropped create-git-tags), breaking the merge workflow. Pin all data-platform-workflows references (build_publish, pull_request, security-compliance) to the matched tag v49.0.3 (which carries the 60-min build timeout) instead of tracking @main, and grant the publish job the actions:read and contents:write permissions that release_rock_edge requires.