### PR TITLE
fix(workflows): align caller permissions with reusable publish workflow

### DIFF
--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -39,7 +39,8 @@ jobs:
   build-and-publish:
     needs: allrocks
     permissions:
-      contents: read
+      actions: read
+      contents: write
       packages: write
     uses: ./.github/workflows/build_publish.yaml
     with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,8 @@ jobs:
   build-and-publish:
     needs: modified_rocks
     permissions:
-      contents: read
+      actions: read
+      contents: write
       packages: write
     uses: ./.github/workflows/build_publish.yaml
     with:


### PR DESCRIPTION
Grant the build-and-publish caller jobs in publish_branch and push the permissions required by build_publish.yaml.

This adds actions: read and contents: write so the nested reusable workflows can satisfy the build_rock and release_rock_edge permission requirements during workflow validation.

Assisted-by: Codex:gpt-5.4-codex