### PR TITLE
fix(workflows): skip reusable rock builds when no rocks changed

### DIFF
--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -38,8 +38,10 @@ jobs:
           echo "rocks=$all_rocks" >> $GITHUB_OUTPUT
   build-and-publish:
     needs: allrocks
+    if: ${{ needs.allrocks.outputs.rocks != '[]' }}
     permissions:
-      contents: read
+      actions: read
+      contents: write
       packages: write
     uses: ./.github/workflows/build_publish.yaml
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build rock
     needs: modified_rocks
+    if: ${{ needs.modified_rocks.outputs.rocks != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,8 +14,10 @@ jobs:
 
   build-and-publish:
     needs: modified_rocks
+    if: ${{ needs.modified_rocks.outputs.rocks != '[]' }}
     permissions:
-      contents: read
+      actions: read
+      contents: write
       packages: write
     uses: ./.github/workflows/build_publish.yaml
     with:


### PR DESCRIPTION
Guard the push, pull_request, and publish_branch workflows so they do not call matrix-based rock build jobs with an empty rock list.

This avoids GitHub Actions validation failures like: "Matrix vector 'rock' does not contain any values".

Also align caller permissions for reusable publish workflows by granting actions: read and contents: write where required.

Assisted-by: Codex:gpt-5.4-codex