### PR TITLE
feat(gnocchi-api): add python3-boto3 for S3 support

### DIFF
--- a/rocks/gnocchi-api/rockcraft.yaml
+++ b/rocks/gnocchi-api/rockcraft.yaml
@@ -44,6 +44,7 @@ parts:
       - sudo
       - gnocchi-api
       - ceph-common
+      - python3-boto3
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf


### PR DESCRIPTION
Add `python3-boto3` to Gnocchi rock to enable S3 access.