### PR TITLE
feat(gnocchi-metricd,gnocchi-consolidated): add python3-boto3 for S3 support

### DIFF
--- a/rocks/gnocchi-consolidated/rockcraft.yaml
+++ b/rocks/gnocchi-consolidated/rockcraft.yaml
@@ -41,6 +41,7 @@ parts:
       - gnocchi-api
       - gnocchi-metricd
       - ceph-common
+      - python3-boto3
     override-prime: |
       craftctl default
       echo > $CRAFT_PRIME/etc/apache2/ports.conf

--- a/rocks/gnocchi-metricd/rockcraft.yaml
+++ b/rocks/gnocchi-metricd/rockcraft.yaml
@@ -46,3 +46,4 @@ parts:
       - sudo
       - gnocchi-metricd
       - ceph-common
+      - python3-boto3


### PR DESCRIPTION
Enable `boto3` for Gnocchi in the consolidated and `metricd` rocks, related to PR #157 